### PR TITLE
Refactor: Split search by title and content into two separate methods

### DIFF
--- a/src/main/java/com/team/mementee/api/controller/SearchController.java
+++ b/src/main/java/com/team/mementee/api/controller/SearchController.java
@@ -27,9 +27,11 @@ public class SearchController {
     // 제목, 내용, 학과
     @GetMapping("/api/search")
     public CommonApiResponse<?> getSearchFilters(@RequestParam String query) {
-        List<Board> boards = boardService.findAllByTitleOrContentContaining(query);
-        List<SubBoard> subBoards = subBoardService.findAllByTitleOrContentContaining(query);
-        return CommonApiResponse.createSuccess(SearchDTO.toEntity(boards, subBoards));
+        List<Board> boards_title = boardService.findAllByTitleContaining(query);
+        List<Board> boards_content = boardService.findAllByContentContaining(query);
+        List<SubBoard> subBoards_title = subBoardService.findAllByTitleContaining(query);
+        List<SubBoard> subBoards_content = subBoardService.findAllByContentContaining(query);
+        return CommonApiResponse.createSuccess(SearchDTO.toEntity(boards_title, subBoards_title, boards_content, subBoards_content));
     }
 
 }

--- a/src/main/java/com/team/mementee/api/dto/searchDTO/SearchDTO.java
+++ b/src/main/java/com/team/mementee/api/dto/searchDTO/SearchDTO.java
@@ -12,16 +12,22 @@ import java.util.List;
 @Builder
 public class SearchDTO {
 
-    private List<String> boards;
-    private List<String> subBoards_quest;
-    private List<String> subBoards_request;
+    private List<String> boards_title;
+    private List<String> subBoards_quest_title;
+    private List<String> subBoards_request_title;
+    private List<String> boards_content;
+    private List<String> subBoards_quest_content;
+    private List<String> subBoards_request_content;
 
 
-    public static SearchDTO toEntity(List<Board> boards, List<SubBoard> subBoards) {
+    public static SearchDTO toEntity(List<Board> boards_title, List<SubBoard> subBoards_title, List<Board> boards_content, List<SubBoard> subBoards_content) {
         return SearchDTO.builder()
-                .boards(boards.stream().map(Board::getTitle).toList())
-                .subBoards_quest(subBoards.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.QUEST).map(SubBoard::getTitle).toList())
-                .subBoards_request(subBoards.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.REQUEST).map(SubBoard::getTitle).toList())
+                .boards_title(boards_title.stream().map(Board::getTitle).toList())
+                .subBoards_quest_title(subBoards_title.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.QUEST).map(SubBoard::getTitle).toList())
+                .subBoards_request_title(subBoards_title.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.REQUEST).map(SubBoard::getTitle).toList())
+                .boards_content(boards_content.stream().map(Board::getTitle).toList())
+                .subBoards_quest_content(subBoards_content.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.REQUEST).map(SubBoard::getTitle).toList())
+                .subBoards_request_content(subBoards_content.stream().filter(subBoard -> subBoard.getSubBoardType() == SubBoardType.REQUEST).map(SubBoard::getTitle).toList())
                 .build();
     }
 

--- a/src/main/java/com/team/mementee/api/repository/board/BoardRepository.java
+++ b/src/main/java/com/team/mementee/api/repository/board/BoardRepository.java
@@ -17,8 +17,8 @@ import java.util.List;
 public interface BoardRepository extends JpaRepository<com.team.mementee.api.domain.Board, Long>{
 
     // 제목 검색
-    @Query("SELECT b FROM Board b WHERE b.title LIKE %:keyword% OR b.content LIKE %:keyword%")
-    List<Board> findAllByTitleOrContentContaining(@Param("keyword") String keyword);
+    List<Board> findAllByTitleContaining(String query);
+    List<Board> findAllByContentContaining(String query);
 
     //특정 멤버가 작성한 게시물
     Page<Board> findBoardsByMember(Member member, Pageable pageable);

--- a/src/main/java/com/team/mementee/api/repository/subBoard/SubBoardRepository.java
+++ b/src/main/java/com/team/mementee/api/repository/subBoard/SubBoardRepository.java
@@ -16,8 +16,8 @@ import java.util.List;
 public interface SubBoardRepository extends JpaRepository<SubBoard, Long> {
 
     // 제목 검색
-    @Query("SELECT s FROM SubBoard s WHERE s.title LIKE %:keyword% OR s.content LIKE %:keyword%")
-    List<SubBoard> findAllByTitleOrContentContaining(@Param("keyword") String keyword);
+    List<SubBoard> findAllByTitleContaining(String query);
+    List<SubBoard> findAllByContentContaining(String query);
 
     //특정 멤버가 작성한 게시물
     Page<SubBoard> findSubBoardsBySubBoardTypeAndMember(SubBoardType subBoardType, Member member, Pageable pageable);

--- a/src/main/java/com/team/mementee/api/service/BoardService.java
+++ b/src/main/java/com/team/mementee/api/service/BoardService.java
@@ -39,8 +39,12 @@ public class BoardService {
     private final MemberService memberService;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public List<Board> findAllByTitleOrContentContaining(String query) {
-        return boardRepository.findAllByTitleOrContentContaining(query);
+    public List<Board> findAllByTitleContaining(String query) {
+        return boardRepository.findAllByTitleContaining(query);
+    }
+
+    public List<Board> findAllByContentContaining(String query) {
+        return boardRepository.findAllByContentContaining(query);
     }
 
     //게시글 조회시 필요한 Info

--- a/src/main/java/com/team/mementee/api/service/SubBoardService.java
+++ b/src/main/java/com/team/mementee/api/service/SubBoardService.java
@@ -40,8 +40,12 @@ public class SubBoardService {
     private final MemberService memberService;
     private final S3Service s3Service;
 
-    public List<SubBoard> findAllByTitleOrContentContaining(String query) {
-        return subBoardRepository.findAllByTitleOrContentContaining(query);
+    public List<SubBoard> findAllByTitleContaining(String query) {
+        return subBoardRepository.findAllByTitleContaining(query);
+    }
+
+    public List<SubBoard> findAllByContentContaining(String query) {
+        return subBoardRepository.findAllByContentContaining(query);
     }
 
     //게시글 조회시 필요한 Info


### PR DESCRIPTION
- Separated the combined title and content search into individual methods:
  1. findAllByTitleContaining(query)
  2. findAllByContentContaining(query)
- This change improves code clarity and allows more flexibility in performing specific searches.